### PR TITLE
x86-qemu: Fix cr0 and cr3 not set on other CPUs after calling vme_init().

### DIFF
--- a/am/src/x86/qemu/cte.c
+++ b/am/src/x86/qemu/cte.c
@@ -151,6 +151,8 @@ Context* kcontext(Area kstack, void (*entry)(void *), void *arg) {
   ctx->eflags = FL_IF;
   ctx->esp    = (uintptr_t)kstack.end;
 #endif
+  // If vme_init() has not been called before, cr3 is zero.
+  ctx->cr3    = __am_kpt;
 
   ctx->GPR1 = (uintptr_t)arg;
   ctx->GPR2 = (uintptr_t)entry;

--- a/am/src/x86/qemu/mpe.c
+++ b/am/src/x86/qemu/mpe.c
@@ -25,6 +25,7 @@ bool mpe_init(void (*entry)()) {
 
 static void othercpu_entry() {
   __am_percpu_init();
+  __am_othercpu_initvme();
   xchg(&ap_ready, 1);
   call_user_entry();
 }

--- a/am/src/x86/qemu/vme.c
+++ b/am/src/x86/qemu/vme.c
@@ -33,7 +33,7 @@ static const struct vm_area vm_areas[] = {
 };
 #define uvm_area (vm_areas[0].area)
 
-static uintptr_t *kpt;
+uintptr_t *__am_kpt;
 static void *(*pgalloc)(int size);
 static void (*pgfree)(void *);
 
@@ -92,7 +92,7 @@ bool vme_init(void *(*_pgalloc)(int size), void (*_pgfree)(void *)) {
   pgfree  = _pgfree;
 
 #if __x86_64__
-  kpt = (void *)PML4_ADDR;
+  __am_kpt = (void *)PML4_ADDR;
 #else
   AddrSpace as;
   as.ptr = NULL;
@@ -106,10 +106,10 @@ bool vme_init(void *(*_pgalloc)(int size), void (*_pgfree)(void *)) {
       }
     }
   }
-  kpt = (void *)baseof((uintptr_t)as.ptr);
+  __am_kpt = (void *)baseof((uintptr_t)as.ptr);
 #endif
 
-  set_cr3(kpt);
+  set_cr3(__am_kpt);
   set_cr0(get_cr0() | CR0_PG);
   return true;
 }
@@ -125,7 +125,7 @@ void protect(AddrSpace *as) {
            cur != (uintptr_t)vma->area.end;
            cur += (1L << info->shift)) {
         int index = indexof(cur, info);
-        upt[index] = kpt[index];
+        upt[index] = __am_kpt[index];
       }
     }
   }

--- a/am/src/x86/qemu/vme.c
+++ b/am/src/x86/qemu/vme.c
@@ -34,6 +34,7 @@ static const struct vm_area vm_areas[] = {
 #define uvm_area (vm_areas[0].area)
 
 uintptr_t *__am_kpt;
+static bool vme_enabled;
 static void *(*pgalloc)(int size);
 static void (*pgfree)(void *);
 
@@ -111,6 +112,7 @@ bool vme_init(void *(*_pgalloc)(int size), void (*_pgfree)(void *)) {
 
   set_cr3(__am_kpt);
   set_cr0(get_cr0() | CR0_PG);
+  vme_enabled = true;
   return true;
 }
 
@@ -178,4 +180,11 @@ Context *ucontext(AddrSpace *as, Area kstack, void *entry) {
   ctx->cr3 = as->ptr;
 
   return ctx;
+}
+
+void __am_othercpu_initvme() {
+  if (vme_enabled) {
+    set_cr3(__am_kpt);
+    set_cr0(get_cr0() | CR0_PG);
+  }
 }

--- a/am/src/x86/qemu/x86-qemu.h
+++ b/am/src/x86/qemu/x86-qemu.h
@@ -93,6 +93,7 @@ void __am_percpu_init();
 Area __am_heap_init();
 void __am_lapic_init();
 void __am_othercpu_entry();
+void __am_othercpu_initvme();
 void __am_percpu_initirq();
 void __am_percpu_initgdt();
 void __am_percpu_initlapic();

--- a/am/src/x86/qemu/x86-qemu.h
+++ b/am/src/x86/qemu/x86-qemu.h
@@ -70,6 +70,7 @@ struct trap_frame {
 extern volatile uint32_t *__am_lapic;
 extern int __am_ncpu;
 extern struct cpu_local __am_cpuinfo[MAX_CPU];
+extern uintptr_t *__am_kpt;
 
 #define CPU (&__am_cpuinfo[cpu_current()])
 


### PR DESCRIPTION
## Problems
1. When the user context(cr3 != 0) switch to the kernel context(cr3 == 0) in `__am_irq()`, the following code will make the kernel context inherit the cr3 of the user context:
```
void __am_irq_handle(struct trap_frame *tf) {
  ...
  //  If ret_ctx is kernel context(cr3 == 0), this branch will not be entered.
  if (ret_ctx->cr3) {
    set_cr3(ret_ctx->cr3);
#if __x86_64__
    CPU->tss.rsp0 = ret_ctx->rsp0;
#else
    CPU->tss.ss0  = KSEL(SEG_KDATA);
    CPU->tss.esp0 = ret_ctx->esp0;
#endif
  }

  // now cr3 is the previous context cr3.
  __am_iret(ret_ctx);
}
```
2. `ap` does not enable paging after calling `vme_init()`, it will make the user process run abnormally on i386.
## How to fix
1. Set cr3 as the kernel page table `__am_kpt` when initializing `ap` and calling `kcontext()`.
2. Enable paging on `ap` if `vme_init()` is called