### PR TITLE
fix(am/src/native/ioe/gpu.c): Replace SDL_WINDOW_SHOWN flag with SDL_WINDOW_OPENGL

### DIFF
--- a/am/src/native/ioe/gpu.c
+++ b/am/src/native/ioe/gpu.c
@@ -36,7 +36,7 @@ void __am_gpu_init() {
 #else
       W * 2, H * 2,
 #endif
-      SDL_WINDOW_SHOWN);
+      SDL_WINDOW_OPENGL);
   surface = SDL_CreateRGBSurface(SDL_SWSURFACE, W, H, 32,
       RMASK, GMASK, BMASK, AMASK);
   SDL_AddTimer(1000 / FPS, texture_sync, NULL);


### PR DESCRIPTION
1. SDL_WINDOW_SHOWN flag has removed after SDL2.26.1
2. After sdl2-2.0.22-1, it causes the sdl window to randomly not appear

复现过程及环境: [SDL_WINDOW_SHOWN-flag-Removed.pdf](https://github.com/NJU-ProjectN/abstract-machine/files/11002592/SDL_WINDOW_SHOWN-flag-Removed.pdf)
SDL版本 2.26.1-1
OPENGL: mesa 22.3.2-3
`am-kernel/kernels/slider` 目录下 运行 `make ARCH=native run`
预期: 正常出现 slider 展示窗口
现象: 反复运行, 大部分情况下出现一个不完整窗口闪现后小时,只能通过 `Ctrl+\`退出
SDL_WINDOW_SHOWN被移除了（https://github.com/libsdl-org/SDL/pull/6926). 通过把标志改为SDL_WINDOW_OPENGL可以正常运行了.

我的系统环境中，包含sdl2-2.0.22-1以后至最新版本都存在上述情况。

做如下调整也可以在以上版本中得到正常结果。同时需要注意SDL_WINDOW_SHOWN标志在 2.26.1以后已经从代码中移除，SDL3/SDL_video.h中

已经去掉该符号，SDL2/SDL_video.h中还有.
![mmexport1679065076633](https://user-images.githubusercontent.com/25432932/225941463-60ce1bdf-a793-4380-86b6-9abc27f3eff1.jpg)

我用git bisect定位到第一次bad commit是60ddb74cfe6b8c20a1e0c6afa473990c6467ea40，然后用替换的方法定位到具体是下图这个位置的代码造成了预期外的问题。删掉sdl库中的这部分编译安装就能够用原am native的代码按预期运行。

![mmexport1679065173244](https://user-images.githubusercontent.com/25432932/225941803-891dda83-df11-4f07-8427-7f95b4764c94.jpg)
src/video/SDL_video.c的2483-2499行。

在使用该commit以后的SDL库时，具体表现是通过SDL_GetWindowFlags函数，发现am创建的window 的SDL_WindowFlags, 的标志位在预期外运行情况下会为4和516，即
SDL_WINDOW_OPENGL = 0x00000002没有被成功设置的，在少数偶尔正常运行情况下，窗口标志位为6和518。

而使用该commit 之前的SDL库，运行情况正常符合预期，但am窗口的标志位一直为4和516。

![mmexport1679065246155](https://user-images.githubusercontent.com/25432932/225942220-f4999e94-0719-4527-80c8-68d3d6025e79.jpg)

高版本下创建窗口后立即调用一次  SDL_GetWindowSurface(window);意外也能正确设置标志位，正常渲染窗口。

总结：只做如下修改是改动最小的. 将 SDL_WINDOW_SHOWN 修改为 SDL_WINDOW_OPENGL. 同时可能核心显卡需要安装 mesa 作为 opengl的库实现

在最新版本的SDL库中，这部分代码也还未完善. https://github.com/libsdl-org/SDL/commit/60ddb74cfe6b8c20a1e0c6afa473990c6467ea40
![mmexport1679065508565](https://user-images.githubusercontent.com/25432932/225943389-4394503c-4512-4fda-ac45-6c934b630c32.jpg)
阻塞的原因就不清楚了，我试了xfce桌面环境和另一种窗口管理器，没有解决。

起先以为是自己的环境共同导致了这个现象, 但是今天一位同学遇到不同现象的问题, 也通过修改该参数解决, 因此来提个pr :).
![mmexport1679065684785](https://user-images.githubusercontent.com/25432932/225944127-824d1dc7-c3d0-4509-b1e4-ad5b1a457a83.jpg)


![mmexport1679065690800](https://user-images.githubusercontent.com/25432932/225944208-10f72353-4221-4332-9343-fffca11d2274.jpg)