### PR TITLE
fix(ftrace): ftrace cannot trace _start and __am_asm_trap 

### DIFF
--- a/am/src/loongarch/nemu/start.S
+++ b/am/src/loongarch/nemu/start.S
@@ -6,3 +6,4 @@ _start:
   move $fp, $zero
   la.local $sp, _stack_pointer
   bl _trm_init
+.size _start, .-_start

--- a/am/src/loongarch/nemu/trap.S
+++ b/am/src/loongarch/nemu/trap.S
@@ -23,6 +23,7 @@ f(30) f(31)
 
 .align 6
 .globl __am_asm_trap
+.type __am_asm_trap, @function
 __am_asm_trap:
   addi.w $sp, $sp, -CONTEXT_SIZE
 
@@ -48,3 +49,4 @@ __am_asm_trap:
 
   addi.w $sp, $sp, CONTEXT_SIZE
   ertn
+.size __am_asm_trap, .-__am_asm_trap

--- a/am/src/mips/nemu/start.S
+++ b/am/src/mips/nemu/start.S
@@ -6,5 +6,6 @@ _start:
   move $fp, $zero
   la $sp, _stack_pointer
   jal _trm_init
+.size _start, .-_start
 
 .fill 0x200

--- a/am/src/mips/nemu/trap.S
+++ b/am/src/mips/nemu/trap.S
@@ -25,6 +25,7 @@ f(30) f(31)
 
 .set noat
 .globl __am_asm_trap
+.type __am_asm_trap, @function
 __am_asm_trap:
   move $k1, $sp
   addiu $sp, $sp, -CONTEXT_SIZE
@@ -69,3 +70,4 @@ __am_asm_trap:
 
   addiu $sp, $sp, CONTEXT_SIZE
   eret
+.size __am_asm_trap, .-__am_asm_trap

--- a/am/src/riscv/nemu/start.S
+++ b/am/src/riscv/nemu/start.S
@@ -6,3 +6,4 @@ _start:
   mv s0, zero
   la sp, _stack_pointer
   jal _trm_init
+.size _start, .-_start

--- a/am/src/riscv/nemu/trap.S
+++ b/am/src/riscv/nemu/trap.S
@@ -29,6 +29,7 @@ f(30) f(31)
 
 .align 3
 .globl __am_asm_trap
+.type __am_asm_trap, @function
 __am_asm_trap:
   addi sp, sp, -CONTEXT_SIZE
 
@@ -59,3 +60,4 @@ __am_asm_trap:
 
   addi sp, sp, CONTEXT_SIZE
   mret
+.size __am_asm_trap, .-__am_asm_trap

--- a/am/src/x86/nemu/start.S
+++ b/am/src/x86/nemu/start.S
@@ -6,3 +6,4 @@ _start:
   mov $0, %ebp
   mov $_stack_pointer, %esp
   call _trm_init                 # never return
+.size _start, .-_start

--- a/am/src/x86/nemu/trap.S
+++ b/am/src/x86/nemu/trap.S
@@ -5,6 +5,8 @@
 .globl __am_vecnull;  __am_vecnull: pushl   $-1; jmp __am_asm_trap
 
 
+.globl __am_asm_trap
+.type __am_asm_trap, @function
 __am_asm_trap:
   pushal
 
@@ -20,3 +22,4 @@ __am_asm_trap:
   addl $4, %esp
 
   iret
+.size __am_asm_trap, .-__am_asm_trap


### PR DESCRIPTION
# Problem:
`_start` 和 `__am_asm_trap` 这两个符号的 `st_info` 和 `st_size` 没有被正确设置, 导致实现的 ftrace 不显示这两个函数调用。
# Details:
以 `am-test` 用户程序为例, 使用readelf命令查看ELF可执行文件的信息:
```bash
>>> readelf -s amtest-riscv32-nemu.elf
Symbol table '.symtab' contains 220 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
...................
   187: 80000000     0 FUNC    GLOBAL DEFAULT    1 _start
   200: 80001528     0 NOTYPE  GLOBAL DEFAULT    1 __am_asm_trap
...................
```
修复后
```bash
>>> readelf -s amtest-riscv32-nemu.elf
Symbol table '.symtab' contains 220 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
...................
   187: 80000000    16 FUNC    GLOBAL DEFAULT    1 _start
   200: 80001528   312 FUNC    GLOBAL DEFAULT    1 __am_asm_trap
...................
```
因为我的 ftrace 是在 nemu 中实现的，所以仅修改了 platform 为 nemu 的情况。
另外，在 navy_apps 项目中, `$NAVY_HOME/libs/libos/src/crt0/start/$ISA.S` 中 `_start` 符号也有上述问题，可以采取相同的修复方案。