### PR TITLE
feat: aarch64 linux support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,10 @@ CFLAGS   += -O2 -MMD -Wall -Werror $(INCFLAGS) \
             -D__PLATFORM__=$(PLATFORM) -D__PLATFORM_$(shell echo $(PLATFORM) | tr a-z A-Z | tr - _) \
             -DARCH_H=\"$(ARCH_H)\" \
             -fno-asynchronous-unwind-tables -fno-builtin -fno-stack-protector \
-            -Wno-main -U_FORTIFY_SOURCE -fvisibility=hidden
+            -Wno-main -U_FORTIFY_SOURCE -fvisibility=hidden $(shell sdl2-config --cflags)
 CXXFLAGS +=  $(CFLAGS) -ffreestanding -fno-rtti -fno-exceptions
 ASFLAGS  += -MMD $(INCFLAGS)
-LDFLAGS  += -z noexecstack
+LDFLAGS  += -z noexecstack $(shell sdl2-config --libs)
 
 ## 4. Arch-Specific Configurations
 

--- a/am/include/arch/native.h
+++ b/am/include/arch/native.h
@@ -15,11 +15,24 @@ struct Context {
   uint8_t redzone[128];
 };
 
+#ifdef __x86_64__
 #define GPR1 uc.uc_mcontext.gregs[REG_RDI]
 #define GPR2 uc.uc_mcontext.gregs[REG_RSI]
 #define GPR3 uc.uc_mcontext.gregs[REG_RDX]
 #define GPR4 uc.uc_mcontext.gregs[REG_RCX]
 #define GPRx uc.uc_mcontext.gregs[REG_RAX]
+#elif __aarch64__
+#define REG_X0 0
+#define REG_X1 1
+#define REG_X2 2
+#define REG_X3 3
+
+#define GPR1 uc.uc_mcontext.regs[REG_X0]
+#define GPR2 uc.uc_mcontext.regs[REG_X1]
+#define GPR3 uc.uc_mcontext.regs[REG_X2]
+#define GPR4 uc.uc_mcontext.regs[REG_X3]
+#define GPRx uc.uc_mcontext.regs[REG_X0]
+#endif
 
 #undef __USE_GNU
 

--- a/am/src/native/cte.c
+++ b/am/src/native/cte.c
@@ -20,9 +20,15 @@ static void irq_handle(Context *c) {
   c->ksp = thiscpu->ksp;
 
   if (thiscpu->ev.event == EVENT_ERROR) {
+#ifdef __x86_64__
     uintptr_t rip = c->uc.uc_mcontext.gregs[REG_RIP];
     printf("Unhandle signal '%s' at rip = %p, badaddr = %p, cause = 0x%x\n",
-        thiscpu->ev.msg, rip, thiscpu->ev.ref, thiscpu->ev.cause);
+      thiscpu->ev.msg, rip, thiscpu->ev.ref, thiscpu->ev.cause);
+#elif __aarch64__
+    uintptr_t rip = c->uc.uc_mcontext.pc;
+    printf("Unhandle signal '%s' at pc = %p, badaddr = %p, cause = 0x%x\n",
+      thiscpu->ev.msg, rip, thiscpu->ev.ref, thiscpu->ev.cause);
+#endif
     assert(0);
   }
   c = user_handler(thiscpu->ev, c);
@@ -37,7 +43,11 @@ static void irq_handle(Context *c) {
 }
 
 static void setup_stack(uintptr_t event, ucontext_t *uc) {
+#ifdef __x86_64__
   void *rip = (void *)uc->uc_mcontext.gregs[REG_RIP];
+#elif __aarch64__
+  void *rip = (void *)uc->uc_mcontext.pc;
+#endif
   extern uint8_t _start, _etext;
   int trap_from_user = __am_in_userspace(rip);
   int signal_safe = IN_RANGE(rip, RANGE(&_start, &_etext)) || trap_from_user ||
@@ -60,10 +70,16 @@ static void setup_stack(uintptr_t event, ucontext_t *uc) {
 
   // skip the instructions causing SIGSEGV for syscall
   if (event == EVENT_SYSCALL) { rip += SYSCALL_INSTR_LEN; }
+#ifdef __x86_64__
   uc->uc_mcontext.gregs[REG_RIP] = (uintptr_t)rip;
 
   // switch to kernel stack if we were previously in user space
   uintptr_t rsp = trap_from_user ? thiscpu->ksp : uc->uc_mcontext.gregs[REG_RSP];
+#elif __aarch64__
+  uc->uc_mcontext.pc = (uintptr_t)rip;
+
+  uintptr_t rsp = trap_from_user ? thiscpu->ksp : uc->uc_mcontext.sp;
+#endif
   rsp -= sizeof(Context);
   // keep (rsp + 8) % 16 == 0 to support SSE
   if ((rsp + 8) % 16 != 0) rsp -= 8;
@@ -76,17 +92,31 @@ static void setup_stack(uintptr_t event, ucontext_t *uc) {
   __am_get_intr_sigmask(&uc->uc_sigmask);
 
   // call irq_handle after returning from the signal handler
+#ifdef __x86_64__
   uc->uc_mcontext.gregs[REG_RDI] = (uintptr_t)c;
   uc->uc_mcontext.gregs[REG_RIP] = (uintptr_t)irq_handle;
   uc->uc_mcontext.gregs[REG_RSP] = (uintptr_t)c;
+#elif __aarch64__
+  uc->uc_mcontext.regs[REG_X0] = (uintptr_t)c;
+  uc->uc_mcontext.pc = (uintptr_t)irq_handle;
+  uc->uc_mcontext.sp = (uintptr_t)uc->uc_mcontext.sp;
+#endif
 }
 
 static void iret(ucontext_t *uc) {
+#ifdef __x86_64__
   Context *c = (void *)uc->uc_mcontext.gregs[REG_RDI];
+#elif __aarch64__
+  Context *c = (void *)uc->uc_mcontext.regs[REG_X0];
+#endif
   // restore the context
   *uc = c->uc;
   thiscpu->ksp = c->ksp;
+#ifdef __x86_64__
   if (__am_in_userspace((void *)uc->uc_mcontext.gregs[REG_RIP])) __am_pmem_protect();
+#elif __aarch64__
+  if (__am_in_userspace((void *)uc->uc_mcontext.pc)) __am_pmem_protect();
+#endif
 }
 
 static void sig_handler(int sig, siginfo_t *info, void *ucontext) {
@@ -167,8 +197,13 @@ Context* kcontext(Area kstack, void (*entry)(void *), void *arg) {
   Context *c = (Context*)kstack.end - 1;
 
   __am_get_example_uc(c);
+#ifdef __x86_64__
   c->uc.uc_mcontext.gregs[REG_RIP] = (uintptr_t)__am_kcontext_start;
   c->uc.uc_mcontext.gregs[REG_RSP] = (uintptr_t)kstack.end;
+#elif __aarch64__
+  c->uc.uc_mcontext.pc = (uintptr_t)__am_kcontext_start;
+  c->uc.uc_mcontext.sp = (uintptr_t)kstack.end;
+#endif
 
   int ret = sigemptyset(&(c->uc.uc_sigmask)); // enable interrupt
   assert(ret == 0);

--- a/am/src/native/ioe/input.c
+++ b/am/src/native/ioe/input.c
@@ -1,5 +1,5 @@
 #include <am.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #define KEYDOWN_MASK 0x8000
 

--- a/am/src/native/platform.c
+++ b/am/src/native/platform.c
@@ -150,7 +150,9 @@ static void init_platform() {
 
   // save the context template
   save_example_context();
+#ifdef __x86_64__
   uc_example.uc_mcontext.fpregs = NULL; // clear the FPU context
+#endif
   __am_get_intr_sigmask(&uc_example.uc_sigmask);
 
   // disable interrupts by default

--- a/am/src/native/trap.S
+++ b/am/src/native/trap.S
@@ -1,5 +1,6 @@
 .global __am_kcontext_start
 __am_kcontext_start:
+#ifdef __x86_64__
   // rdi = arg, rsi = entry
 
   // (rsp + 8) should be multiple of 16 when
@@ -8,3 +9,14 @@ __am_kcontext_start:
   andq $0xfffffffffffffff0, %rsp
   call *%rsi
   call __am_panic_on_return
+#elif __aarch64__
+  // x0 = arg, x1 = entry
+  // (sp + 16) should be multiple of 16 when
+  // control is transfered to the function entry point.
+  // See aarch64 ABI manual for more details
+  // https://github.com/ARM-software/abi-aa
+  mov x2, sp
+  and sp, x2, #0xfffffffffffffff0
+  br x1
+  bl __am_panic_on_return
+#endif

--- a/am/src/native/vme.c
+++ b/am/src/native/vme.c
@@ -124,8 +124,13 @@ Context* ucontext(AddrSpace *as, Area kstack, void *entry) {
   Context *c = (Context*)kstack.end - 1;
 
   __am_get_example_uc(c);
+#ifdef __x86_64__
   c->uc.uc_mcontext.gregs[REG_RIP] = (uintptr_t)entry;
   c->uc.uc_mcontext.gregs[REG_RSP] = (uintptr_t)USER_SPACE.end;
+#elif __aarch64__
+  c->uc.uc_mcontext.pc = (uintptr_t)entry;
+  c->uc.uc_mcontext.sp = (uintptr_t)USER_SPACE.end;
+#endif
 
   int ret = sigemptyset(&(c->uc.uc_sigmask)); // enable interrupt
   assert(ret == 0);


### PR DESCRIPTION
ysyx 做 PA 过程中发现 arm native 有适配问题，因为 glibc 的 ucontext 在 x86 [1] 和 aarch64 [2] 下的实现不同，需要做移植才能编译成功，另外还参考了 [3]。

测试结果，使用 OrbStack [4] 启动 aarch Linux Docker。具体的 cte 功能测试等完成  PA 后继续修改。
```shell
$ uname -a
Linux ubuntu 6.5.7-orbstack-00109-gd8500ae6683d #1 SMP Fri Oct 13 01:28:33 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux

$ cd am-kernels/tests/cpu-tests/ && make ARCH=native run
...
 fact sub-longlong sum shift load-store max quick-sort leap-year mov-c unalign mersenne wanshu hello-str if-else switch add-longlong recursion pascal string div select-sort dummy crc32 bubble-sort goldbach prime bit add mul-longlong min3 fib shuixianhua matrix-mul to-lower-case movsx
[          fact] PASS!
[  sub-longlong] PASS!
...
[ to-lower-case] PASS!
[         movsx] PASS!
```

[1]: https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/aarch64/sys/ucontext.h
[2]: https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/x86/sys/ucontext.h
[3]: https://github.com/ARM-software/abi-aa
[4]: https://orbstack.dev/