### PR TITLE
riscv,nemu,start: add function size for `_start`

### DIFF
--- a/am/src/riscv/nemu/start.S
+++ b/am/src/riscv/nemu/start.S
@@ -6,3 +6,5 @@ _start:
   mv s0, zero
   la sp, _stack_pointer
   jal _trm_init
+
+.size _start, . - _start


### PR DESCRIPTION
Although `_start`, as the entry point of the program, typically does not require a function size, setting a size for it in this case provides more detailed program information.

Before:
```
readelf -s build/hello-riscv64-nemu.elf

Symbol table '.symtab' contains 30 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
   ...
    25: 0000000080000000     0 FUNC    GLOBAL DEFAULT    1 _start
    26: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  ABS _entry_offset
    27: 0000000080000010   124 FUNC    GLOBAL HIDDEN     1 main
    28: 00000000800000f1     0 NOTYPE  GLOBAL DEFAULT    3 _data
    29: 0000000080009000     0 NOTYPE  GLOBAL DEFAULT    3 _end
```

After:
```
readelf -s build/hello-riscv64-nemu.elf 

Symbol table '.symtab' contains 30 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
    ...
    25: 0000000080000000    16 FUNC    GLOBAL DEFAULT    1 _start
    26: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  ABS _entry_offset
    27: 0000000080000010   124 FUNC    GLOBAL HIDDEN     1 main
    28: 00000000800000f1     0 NOTYPE  GLOBAL DEFAULT    3 _data
    29: 0000000080009000     0 NOTYPE  GLOBAL DEFAULT    3 _end
```
