### PR TITLE
fix: Makefile clean-all target did not work as expectation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ clean:
 .PHONY: clean
 
 ### Clean all sub-projects within depth 2 (and ignore errors)
-CLEAN_ALL = $(dir $(shell find . -mindepth 2 -name Makefile))
+CLEAN_ALL = $(dir $(shell find $(AM_HOME) -mindepth 2 -name Makefile))
 clean-all: $(CLEAN_ALL) clean
 $(CLEAN_ALL):
 	-@$(MAKE) -s -C $@ clean


### PR DESCRIPTION
This patch helps the user clean all sub libraries from any directory that uses abstact-machine by `make clean-all`, instead of going into the home directory of abstract-machine and doing that(which is the previous behavior).