### PR TITLE
fix makefile image dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,9 @@ $(LIBS): %:
 	@$(MAKE) -s -C $(AM_HOME)/$* archive
 
 ### Rule (link): objects (`*.o`) and libraries (`*.a`) -> `IMAGE.elf`, the final ELF binary to be packed into image (ld)
-$(IMAGE).elf: $(OBJS) $(LIBS)
+$(IMAGE).elf: $(LINKAGE)
 	@echo + LD "->" $(IMAGE_REL).elf
-	@$(LD) $(LDFLAGS) -o $(IMAGE).elf --start-group $(LINKAGE) --end-group
+	@$(LD) $(LDFLAGS) -o $@ --start-group $^ --end-group
 
 ### Rule (archive): objects (`*.o`) -> `ARCHIVE.a` (ar)
 $(ARCHIVE): $(OBJS)
@@ -138,9 +138,8 @@ $(ARCHIVE): $(OBJS)
 ## 6. Miscellaneous
 
 ### Build order control
-image: image-dep
 archive: $(ARCHIVE)
-image-dep: $(OBJS) $(LIBS)
+image-dep: $(LIBS)
 	@echo \# Creating image [$(ARCH)]
 .PHONY: image image-dep archive run $(LIBS)
 

--- a/scripts/platform/nemu.mk
+++ b/scripts/platform/nemu.mk
@@ -17,10 +17,14 @@ CFLAGS += -DMAINARGS=\"$(mainargs)\"
 CFLAGS += -I$(AM_HOME)/am/src/platform/nemu/include
 .PHONY: $(AM_HOME)/am/src/platform/nemu/trm.c
 
-image: $(IMAGE).elf
-	@$(OBJDUMP) -d $(IMAGE).elf > $(IMAGE).txt
+# `image-dep` should update strictly BEFORE `$(IMAGE).bin`
+.NOTPARALLEL: image
+image: image-dep $(IMAGE).bin
+
+$(IMAGE).bin: $(IMAGE).elf
+	@$(OBJDUMP) -d $< > $(IMAGE).txt
 	@echo + OBJCOPY "->" $(IMAGE_REL).bin
-	@$(OBJCOPY) -S --set-section-flags .bss=alloc,contents -O binary $(IMAGE).elf $(IMAGE).bin
+	@$(OBJCOPY) -S --set-section-flags .bss=alloc,contents -O binary $< $@
 
 run: image
 	$(MAKE) -C $(NEMU_HOME) ISA=$(ISA) run ARGS="$(NEMUFLAGS)" IMG=$(IMAGE).bin

--- a/scripts/platform/npc.mk
+++ b/scripts/platform/npc.mk
@@ -15,7 +15,11 @@ LDFLAGS   += --gc-sections -e _start
 CFLAGS += -DMAINARGS=\"$(mainargs)\"
 .PHONY: $(AM_HOME)/am/src/riscv/npc/trm.c
 
-image: $(IMAGE).elf
-	@$(OBJDUMP) -d $(IMAGE).elf > $(IMAGE).txt
+# `image-dep` should update strictly BEFORE `$(IMAGE).bin`
+.NOTPARALLEL: image
+image: image-dep $(IMAGE).bin
+
+$(IMAGE).bin: $(IMAGE).elf
+	@$(OBJDUMP) -d $< > $(IMAGE).txt
 	@echo + OBJCOPY "->" $(IMAGE_REL).bin
-	@$(OBJCOPY) -S --set-section-flags .bss=alloc,contents -O binary $(IMAGE).elf $(IMAGE).bin
+	@$(OBJCOPY) -S --set-section-flags .bss=alloc,contents -O binary $< $@

--- a/scripts/platform/qemu.mk
+++ b/scripts/platform/qemu.mk
@@ -15,3 +15,5 @@ image: $(IMAGE).elf
 	@$(MAKE) -s -C $(BOOT_HOME)
 	@echo + CREATE "->" $(IMAGE_REL)
 	@( cat $(BOOT_HOME)/bootblock.o; head -c 1024 /dev/zero; cat $(IMAGE).elf ) > $(IMAGE)
+
+# TODO:i know little about qemu framework, so i left it unchanged


### PR DESCRIPTION
Fix dependencies to avoid redundant rebuilding.
Notice I did not fix `scripts/platform/qemu.mk` due to my lack of knowledge.

However the injection logic about `MAINARGS` always trys to rebuild the `am-xxx.a` lib, which makes this fix seems useless.