### PR TITLE
Fix miscompilation issues caused by strict aliasing rules.

### DIFF
--- a/am/src/x86/qemu/boot/main.c
+++ b/am/src/x86/qemu/boot/main.c
@@ -18,8 +18,8 @@ static inline void read_disk(void *buf, int sect) {
   outb(0x1f6, (sect >> 24) | 0xE0);
   outb(0x1f7, 0x20);
   wait_disk();
-  for (int i = 0; i < SECTSIZE / 4; i ++) {
-    ((uint32_t *)buf)[i] = inl(0x1f0);
+  for (int i = 0; i < SECTSIZE / 2; i ++) {
+    ((uint16_t *)buf)[i] = inw(0x1f0);
   }
 }
 


### PR DESCRIPTION
### Description
In versions of GCC after GCC11, a miscompilation occurs when compiling `/abstract-machine/am/src/x86/qemu/boot/main.c`. Specifically, it reads the value of `elf32->e_machine` before  `copy_from_disk(elf32, 4096, 0)`

Assembly code:
**Before repair:**
```asm
*    7d22:	66 8b 1d 12 80 00 00 	mov    0x8012,%bx
     7d29:	e8 34 ff ff ff       	call   7c62 <copy_from_disk>
     7d2e:	31 c9                	xor    %ecx,%ecx
     7d30:	ba 00 10 00 00       	mov    $0x1000,%edx
     7d35:	b8 00 80 00 00       	mov    $0x8000,%eax
     7d3a:	e8 23 ff ff ff       	call   7c62 <copy_from_disk>
*    7d3f:	66 83 fb 3e          	cmp    $0x3e,%bx
```
**After repair:**
```asm
     7d29:	31 c9                	xor    %ecx,%ecx
     7d2b:	ba 00 10 00 00       	mov    $0x1000,%edx
     7d30:	b8 00 80 00 00       	mov    $0x8000,%eax
     7d35:	e8 28 ff ff ff       	call   7c62 <copy_from_disk>
*    7d3a:	66 83 3d 12 80 00 00 	cmpw   $0x3e,0x8012

```


### Changes Made
Change the `(uint32_t *)buf` in the `read_disk` function to `uint16_t *`, and then read two bytes of data from the disk each time.

```c
  outb(0x1f6, (sect >> 24) | 0xE0);
  outb(0x1f7, 0x20);
  wait_disk();
-  for (int i = 0; i < SECTSIZE / 4; i ++) {
-    ((uint32_t *)buf)[i] = inl(0x1f0);
+  for (int i = 0; i < SECTSIZE / 2; i ++) {
+    ((uint16_t *)buf)[i] = inw(0x1f0);
  }
}

```