### PR TITLE
feat: riscv64 linux support

### DIFF
--- a/am/include/arch/native.h
+++ b/am/include/arch/native.h
@@ -16,17 +16,25 @@ struct Context {
 };
 
 #ifdef __x86_64__
-#define GPR1 uc.uc_mcontext.gregs[REG_RDI]
-#define GPR2 uc.uc_mcontext.gregs[REG_RSI]
-#define GPR3 uc.uc_mcontext.gregs[REG_RDX]
-#define GPR4 uc.uc_mcontext.gregs[REG_RCX]
-#define GPRx uc.uc_mcontext.gregs[REG_RAX]
+#define GPR1 uc.uc_mcontext.gregs[AM_REG_RDI]
+#define GPR2 uc.uc_mcontext.gregs[AM_REG_RSI]
+#define GPR3 uc.uc_mcontext.gregs[AM_REG_RDX]
+#define GPR4 uc.uc_mcontext.gregs[AM_REG_RCX]
+#define GPRx uc.uc_mcontext.gregs[AM_REG_RAX]
 #elif __aarch64__
 #define GPR1 uc.uc_mcontext.regs[0]
 #define GPR2 uc.uc_mcontext.regs[1]
 #define GPR3 uc.uc_mcontext.regs[2]
 #define GPR4 uc.uc_mcontext.regs[3]
 #define GPRx uc.uc_mcontext.regs[0]
+#elif __riscv
+#define GPR1 uc.uc_mcontext.__gregs[REG_A0]
+#define GPR2 uc.uc_mcontext.__gregs[REG_A0+1]
+#define GPR3 uc.uc_mcontext.__gregs[REG_A0+2]
+#define GPR4 uc.uc_mcontext.__gregs[REG_A0+3]
+#define GPRx uc.uc_mcontext.__gregs[REG_A0+4]
+#else
+#error Unsupported architecture
 #endif
 
 #undef __USE_GNU

--- a/am/src/native/platform.h
+++ b/am/src/native/platform.h
@@ -8,13 +8,17 @@
 #include <klib-macros.h>
 
 #ifdef __x86_64__
-#define REG_PC(uc)   (uc)->uc_mcontext.gregs[REG_RIP]
-#define REG_SP(uc)   (uc)->uc_mcontext.gregs[REG_RSP]
-#define REG_GPR1(uc) (uc)->uc_mcontext.gregs[REG_RDI]
+#define AM_REG_PC(uc)   (uc)->uc_mcontext.gregs[REG_RIP]
+#define AM_REG_SP(uc)   (uc)->uc_mcontext.gregs[REG_RSP]
+#define AM_REG_GPR1(uc) (uc)->uc_mcontext.gregs[REG_RDI]
 #elif __aarch64__
-#define REG_PC(uc)   (uc)->uc_mcontext.pc
-#define REG_SP(uc)   (uc)->uc_mcontext.sp
-#define REG_GPR1(uc) (uc)->uc_mcontext.regs[0]
+#define AM_REG_PC(uc)   (uc)->uc_mcontext.pc
+#define AM_REG_SP(uc)   (uc)->uc_mcontext.sp
+#define AM_REG_GPR1(uc) (uc)->uc_mcontext.regs[0]
+#elif __riscv && __riscv_xlen == 64
+#define AM_REG_PC(uc)   (uc)->uc_mcontext.__gregs[REG_PC]
+#define AM_REG_SP(uc)   (uc)->uc_mcontext.__gregs[REG_SP]
+#define AM_REG_GPR1(uc) (uc)->uc_mcontext.__gregs[REG_A0]
 #else
 #error Unsupported architecture
 #endif

--- a/am/src/native/trap.S
+++ b/am/src/native/trap.S
@@ -19,4 +19,11 @@ __am_kcontext_start:
   and sp, x2, #0xfffffffffffffff0
   br x1
   bl __am_panic_on_return
+#elif __riscv
+  // See riscv ABI manual for more details
+  // https://github.com/riscv-non-isa/riscv-elf-psabi-doc
+  addi sp, sp, -16
+  andi sp, sp, ~15
+  jalr a1
+  jal  __am_panic_on_return
 #endif

--- a/am/src/native/vme.c
+++ b/am/src/native/vme.c
@@ -124,8 +124,8 @@ Context* ucontext(AddrSpace *as, Area kstack, void *entry) {
   Context *c = (Context*)kstack.end - 1;
 
   __am_get_example_uc(c);
-  REG_PC(&c->uc) = (uintptr_t)entry;
-  REG_SP(&c->uc) = (uintptr_t)USER_SPACE.end;
+  AM_REG_PC(&c->uc) = (uintptr_t)entry;
+  AM_REG_SP(&c->uc) = (uintptr_t)USER_SPACE.end;
 
   int ret = sigemptyset(&(c->uc.uc_sigmask)); // enable interrupt
   assert(ret == 0);


### PR DESCRIPTION
完结之前立下的Flag：https://github.com/NJU-ProjectN/abstract-machine/pull/9#issuecomment-2164253376 ，在 riscv64 机器上跑 native am。现在可以在 riscv64 物理机上做  pa 和 ysyx 了。

测试环境为 riscv64 裸机，SoC 为玄铁（达摩院）的`th1520`，IP 核[`C910`](https://www.xrvm.cn/product/xuantie/C910)，操作系统为 Linux ，测试结果：

```shell
Linux lpi4a16f2 5.10.113-sipeed-20240312+ #10 SMP PREEMPT Tue Mar 12 14:33:06 HKT 2024 riscv64 GNU/Linux

$ lscpu
Architecture:          riscv64
  Byte Order:          Little Endian
CPU(s):                4
  On-line CPU(s) list: 0-3
...

am-kernels/benchmarks/* $ make ARCH=native run
MicroBench PASS        6985 Marks
CoreMark PASS       7917 Marks
Dhrystone PASS         6383 Marks

# cpu-tests 和 am-tests 也均通过
```