### PR TITLE
fix: linker script does not include all subsections of data

### DIFF
--- a/scripts/linker.ld
+++ b/scripts/linker.ld
@@ -14,7 +14,7 @@ SECTIONS {
     *(.rodata*)
   }
   .data : {
-    *(.data)
+    *(.data*)
   } : data
   edata = .;
   _data = .;


### PR DESCRIPTION
By default, we use `-fdata-sections` to remove unused static variables at linking stage. Currently, `*(.data)` but not `*(.data*)` is used by `linker.ld` to refer to data sections. The relative location of `.data` subsections (e.g. `.data.lut`) is determined by the linker. When it is placed after `.bss`, heap addresses and `.data` will be overlap.

This is discovered when trying to compile abstract-machine with clang. 
```sh
> $READELF -S build-clang/images/linpack.elf
There are 18 section headers, starting at offset 0x55e54:

Section Headers:
  [Nr] Name              Type            Address  Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .text             PROGBITS        80000000 001000 01684c 00  AX  0   0  4
  [ 2] .rodata           PROGBITS        8001684c 01784c 000425 00 AMS  0   0  4
  [ 3] .bss              NOBITS          80016c74 017c74 0000c4 00  WA  0   0  4
  [ 4] .data.lut         PROGBITS        80027000 028000 000200 00  WA  0   0  4
  ...
```

```sh
> $NM build-clang/images/linpack.elf | grep _heap_start
80027000 A _heap_start
```