### PR TITLE
为am/src/riscv/npc/start.S 的 `_start` 函数添加 `.size` 属性

### DIFF
--- a/am/src/riscv/npc/start.S
+++ b/am/src/riscv/npc/start.S
@@ -6,3 +6,5 @@ _start:
   mv s0, zero
   la sp, _stack_pointer
   call _trm_init
+
+.size _start, . - _start

--- a/am/src/riscv/spike/start.S
+++ b/am/src/riscv/spike/start.S
@@ -6,3 +6,5 @@ _start:
   mv s0, zero
   la sp, _stack_pointer
   jal _trm_init
+
+.size _start, . - _start


### PR DESCRIPTION
npc和spike的start.S遗漏了`.size` 这一属性，导致在ftrace时无法正确识别到`_start`这一函数。nemu中有该语句，应为遗漏。
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/02d54323-f6b5-47b9-815d-fb3d44195ee1" />

