### PR TITLE
fix: disable the terminal line buffering for serial input when running native program

### DIFF
--- a/am/src/native/ioe/uart.c
+++ b/am/src/native/ioe/uart.c
@@ -4,6 +4,14 @@
 #include <unistd.h>
 #include <assert.h>
 #include <errno.h>
+#include <termios.h>
+#include <stdlib.h>
+
+static struct termios orig_termios;
+
+void __am_uart_cleanup() {
+  tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
+}
 
 void __am_uart_init() {
   int ret = fcntl(STDIN_FILENO, F_GETFL);
@@ -11,6 +19,16 @@ void __am_uart_init() {
   int flag = ret | O_NONBLOCK;
   ret = fcntl(STDIN_FILENO, F_SETFL, flag);
   assert(ret != -1);
+  
+  struct termios new_termios;
+  tcgetattr(STDIN_FILENO, &orig_termios);
+  atexit(__am_uart_cleanup); 
+
+  new_termios = orig_termios;
+  
+  new_termios.c_lflag &= ~(ICANON | ECHO);
+  
+  tcsetattr(STDIN_FILENO, TCSANOW, &new_termios);
 }
 
 void __am_uart_config(AM_UART_CONFIG_T *cfg) {


### PR DESCRIPTION
修改文件：**am/src/native/ioe/uart.c**

### 问题
在运行 native 程序时，终端默认开启输入行缓冲（line buffering）。这导致输入字符无法实时传递给程序，必须按下回车键后才能发送，影响了依赖实时输入的交互功能。具体表现为：

1. 运行 RT-Thread 时，Tab 键补全无法正常触发
2. 字符无法即时响应，无法模拟真实硬件串口行为

### 修改
在 am/src/native/ioe/uart.c 中修改终端输入模式：
1. 关闭 ICANON 标志：禁用规范模式（行缓冲），使字符可实时发送
2. 关闭 ECHO 标志：禁用终端自动回显。由于行缓冲被关闭，若保留回显会导致输入字符重复显示，影响正常输入

当程序结束运行时，会自动恢复原有终端输入模式，确保不影响其他程序的正常使用。

### 修改效果
1. 按键即时响应：输入字符无需等待回车
2. Tab 补全恢复正常：RT-Thread 中的 Tab 补全功能可正常触发
3. 串口交互体验与真实硬件行为保持一致

### 测试说明
测试环境：本地 native 平台（Ubuntu22.04）
测试场景：运行 RT-Thread，验证 Tab 补全及字符即时响应
回归测试：其他依赖串口输入的功能未受影响
