### PR TITLE
fix(strrchr): avoid out-of-bounds access when searching for '\0'

### DIFF
--- a/klib/src/string.c
+++ b/klib/src/string.c
@@ -52,7 +52,7 @@ char *strchr(const char *s, int c) {
 }
 
 char *strrchr(const char *s, int c) {
-  const char *p = s + strlen(s) + 1;
+  const char *p = s + strlen(s);
   do {
     if (*p == c) return (char *)p;
     if (s == p) break;


### PR DESCRIPTION
The previous implementation of strrchr in klib started scanning from s + strlen(s) + 1, which reads one byte beyond the terminating null character. This is undefined behavior and could return the wrong address if that byte happens to be '\0'. In fact, running the following test code:

```c
const char *s = "abca";
assert(strrchr(s, '\0') == s + 4);
```

the assertion fails, demonstrating that this bug can indeed be triggered.

In this version, I change the initial pointer to point to the terminating '\0' itself (s + strlen(s)). This ensures all accesses stay within the string's bounds while still correctly handling the search for '\0'.

I am a student taking Spring 2026 Lab of Open Source Processor Chip Design course in UCAS. Hope this fix helps.