### PR TITLE
fix(am): generalize page size in native platform

### DIFF
--- a/am/src/native/platform.c
+++ b/am/src/native/platform.c
@@ -99,7 +99,8 @@ static void init_platform() {
       // allocate temporary memory
       extern char end;
       void *vaddr = (void *)&end - phdr[i].p_memsz;
-      uintptr_t pad = (uintptr_t)vaddr & 0xfff;
+      uintptr_t page_size = sysconf(_SC_PAGESIZE);
+      uintptr_t pad = (uintptr_t)vaddr & (page_size - 1);
       void *vaddr_align = vaddr - pad;
       uintptr_t size = phdr[i].p_memsz + pad;
       void *temp_mem = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);


### PR DESCRIPTION
On some platforms, especially the Apple Silicon, the system page size is 16K instead of 4K. The hardcoded mask 0xfff assumes 4K pages, causing misaligned addresses to be passed to mmap() with MAP_FIXED, which fails with EINVAL.

This PR will fix the issue by using sysconf(_SC_PAGESIZE) to query the actual page size at runtime.