### PR TITLE
给npc的am添加了声卡抽象寄存器，使bad apple可以正常运行

### DIFF
--- a/am/src/riscv/npc/ioe.c
+++ b/am/src/riscv/npc/ioe.c
@@ -10,6 +10,7 @@ void __am_input_keybrd(AM_INPUT_KEYBRD_T *);
 static void __am_timer_config(AM_TIMER_CONFIG_T *cfg) { cfg->present = true; cfg->has_rtc = true; }
 static void __am_input_config(AM_INPUT_CONFIG_T *cfg) { cfg->present = true;  }
 static void __am_uart_config(AM_INPUT_CONFIG_T *cfg) { cfg->present = false;  }
+static void __am_audio_config(AM_AUDIO_CONFIG_T *cfg) {cfg->present = false; }
 
 typedef void (*handler_t)(void *buf);
 static void *lut[128] = {
@@ -19,6 +20,7 @@ static void *lut[128] = {
   [AM_INPUT_CONFIG] = __am_input_config,
   [AM_INPUT_KEYBRD] = __am_input_keybrd,
   [AM_UART_CONFIG]  = __am_uart_config,
+  [AM_AUDIO_CONFIG] = __am_audio_config,
 };
 
 static void fail(void *buf) { panic("access nonexist register"); }


### PR DESCRIPTION
am-kernels中在npc的bad-apple测试中调用了声卡抽象寄存器，而在npc的ioe.c中没有相关寄存器的定义而且没有相关宏像屏蔽gui一样屏蔽声卡的影响导致了程序进入fail而崩溃，添加后bad-apple可以在npc上正常运行测试